### PR TITLE
テキスト画像出力機能の改善：色とフォント情報の正確な保持

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "tmp",
+  "name": "TextRender",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -11,6 +11,7 @@
   "dependencies": {
     "canvas": "^3.1.0",
     "html-to-image": "^1.11.13",
+    "html2canvas": "^1.4.1",
     "next": "15.3.0",
     "puppeteer": "^24.6.1",
     "react": "^19.0.0",

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from "react";
+import html2canvas from 'html2canvas';
 
 export default function HtmlToImageTool() {
   const [markupUpperText, setMarkupUpperText] = useState(``);
@@ -100,7 +101,7 @@ export default function HtmlToImageTool() {
   // スケールファクター
   const scaleFactor = 360/baseWidth;
   
-  // HTML要素から画像を生成して保存 - 直接Canvas APIを使用
+  // HTML要素から画像を生成して保存 - html2canvasライブラリを使用
   const saveAsImage = async () => {
     if (!textContainerRef.current || isProcessing) return;
     
@@ -115,63 +116,23 @@ export default function HtmlToImageTool() {
       const outputWidth = 1080;
       const outputHeight = 1920;
       
-      // キャンバス要素を作成
-      const canvas = document.createElement('canvas');
-      canvas.width = outputWidth;
-      canvas.height = outputHeight;
-      const ctx = canvas.getContext('2d');
-      
-      // 背景を透明に設定
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      
-      // 上部テキストと下部テキストの文字列をHTML形式で取得
-      const upperTextElement = textContainerRef.current.querySelector('.upper-text');
-      const bottomTextElement = textContainerRef.current.querySelector('.bottom-text');
-      
-      // 上部テキストを描画
-      if (upperTextElement) {
-        const outputUpperTop = (upperTextTop * outputWidth) / 360;
-        
-        // フォント設定
-        ctx.font = `${fontWeight} ${(24 * scaleFactor * textRate * outputWidth) / 360}px ${selectedFont}, sans-serif`;
-        ctx.textBaseline = 'top';
-        ctx.textAlign = 'center';
-        
-        // テキストを中央揃えで行ごとに描画
-        const upperText = upperTextElement.innerText || '';
-        const lines = upperText.split("\n");
-        
-        let currentY = outputUpperTop;
-        lines.forEach((line) => {
-          // 色付きテキスト対応のため一旦黒で描画（後で対応）
-          ctx.fillStyle = '#000000';
-          ctx.fillText(line, outputWidth / 2, currentY);
-          currentY += (24 * scaleFactor * textRate * lineHeight * outputWidth) / 360;
-        });
-      }
-      
-      // 下部テキストを描画
-      if (bottomTextElement) {
-        const outputBottomBottom = (bottomTextBottom * outputWidth) / 360;
-        
-        // フォント設定
-        ctx.font = `${fontWeight} ${(24 * scaleFactor * textRate * outputWidth) / 360}px ${selectedFont}, sans-serif`;
-        ctx.textBaseline = 'bottom';
-        ctx.textAlign = 'center';
-        
-        // テキストを中央揃えで行ごとに描画
-        const bottomText = bottomTextElement.innerText || '';
-        const lines = bottomText.split("\n");
-        
-        let currentY = outputHeight - outputBottomBottom;
-        // ボトムテキストは下から上に配置
-        for (let i = lines.length - 1; i >= 0; i--) {
-          // 色付きテキスト対応のため一旦黒で描画（後で対応）
-          ctx.fillStyle = '#000000';
-          ctx.fillText(lines[i], outputWidth / 2, currentY);
-          currentY -= (24 * scaleFactor * textRate * lineHeight * outputWidth) / 360;
+      // html2canvasを使用してHTML要素をキャンバスに変換
+      const canvas = await html2canvas(textContainerRef.current, {
+        backgroundColor: null, // 透明な背景
+        width: outputWidth,
+        height: outputHeight,
+        scale: 3, // 高解像度用のスケーリング
+        useCORS: true, // 外部リソースの読み込み許可
+        logging: false, // ログ出力を無効化
+        onclone: (clonedDoc) => {
+          // クローンされたDOM要素のスタイル調整
+          const clonedContainer = clonedDoc.querySelector('#text-container');
+          if (clonedContainer) {
+            clonedContainer.style.width = `${outputWidth}px`;
+            clonedContainer.style.height = `${outputHeight}px`;
+          }
         }
-      }
+      });
       
       // Canvas要素からデータURLを生成
       const dataUrl = canvas.toDataURL('image/png');
@@ -209,6 +170,7 @@ export default function HtmlToImageTool() {
             backgroundColor: "transparent",
             overflow: "hidden"
           }}
+          id="text-container"
         >
           {/* 上部テキスト - 絶対配置 */}
           <div

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from "react";
-import { toBlob } from 'html-to-image';
+import { toPng } from 'html-to-image';
 
 export default function HtmlToImageTool() {
   const [markupUpperText, setMarkupUpperText] = useState(``);
@@ -112,34 +112,30 @@ export default function HtmlToImageTool() {
       const now = new Date();
       const timestamp = `${now.getFullYear()}${(now.getMonth()+1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
       
-      // テキスト要素のみを含むコンテナからBlobを生成
-      const blob = await toBlob(textContainerRef.current, {
+      // HTML要素からPNG画像データを生成
+      const dataUrl = await toPng(textContainerRef.current, {
         backgroundColor: null, // 透明な背景
         width: 1080,
-        height: 1920
+        height: 1920,
+        canvasWidth: 1080,
+        canvasHeight: 1920,
+        pixelRatio: 1,
+        skipAutoScale: true,
+        style: {
+          transform: 'scale(3)', // スケールを調整
+          transformOrigin: 'top left'
+        }
       });
-      
-      if (!blob) {
-        throw new Error("画像の生成に失敗しました");
-      }
-      
-      // Blobオブジェクトから一時的なURLを作成
-      const imageUrl = URL.createObjectURL(blob);
       
       // ダウンロードリンク作成
       const link = document.createElement('a');
-      link.href = imageUrl;
       link.download = `text_image_${timestamp}.png`;
-      document.body.appendChild(link);
+      link.href = dataUrl;
       link.click();
-      document.body.removeChild(link);
       
-      // 一時URLの解放
-      URL.revokeObjectURL(imageUrl);
-      
-    } catch (e) {
-      console.error("画像の保存に失敗しました:", e);
-      alert("画像の保存に失敗しました: " + e.message);
+    } catch (error) {
+      console.error("画像の保存に失敗しました:", error);
+      alert("画像の保存に失敗しました: " + (error?.message || "不明なエラー"));
     } finally {
       setIsProcessing(false);
     }

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useRef, useEffect } from "react";
-import { toPng } from 'html-to-image';
+import { toCanvas } from 'html-to-image';
 
 export default function HtmlToImageTool() {
   const [markupUpperText, setMarkupUpperText] = useState(``);
@@ -101,7 +101,7 @@ export default function HtmlToImageTool() {
   // スケールファクター
   const scaleFactor = 360/baseWidth;
   
-  // HTML要素から画像を生成して保存
+  // HTML要素から画像を生成して保存 - Canvas APIを直接使用する方法
   const saveAsImage = async () => {
     if (!textContainerRef.current || isProcessing) return;
     
@@ -112,20 +112,15 @@ export default function HtmlToImageTool() {
       const now = new Date();
       const timestamp = `${now.getFullYear()}${(now.getMonth()+1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
       
-      // HTML要素からPNG画像データを生成
-      const dataUrl = await toPng(textContainerRef.current, {
+      // HTML要素からCanvas要素を作成
+      const canvas = await toCanvas(textContainerRef.current, {
         backgroundColor: null, // 透明な背景
         width: 1080,
-        height: 1920,
-        canvasWidth: 1080,
-        canvasHeight: 1920,
-        pixelRatio: 1,
-        skipAutoScale: true,
-        style: {
-          transform: 'scale(3)', // スケールを調整
-          transformOrigin: 'top left'
-        }
+        height: 1920
       });
+      
+      // Canvas要素からデータURLを生成
+      const dataUrl = canvas.toDataURL('image/png');
       
       // ダウンロードリンク作成
       const link = document.createElement('a');
@@ -135,7 +130,7 @@ export default function HtmlToImageTool() {
       
     } catch (error) {
       console.error("画像の保存に失敗しました:", error);
-      alert("画像の保存に失敗しました: " + (error?.message || "不明なエラー"));
+      alert("画像の保存に失敗しました: " + (error ? error.toString() : "不明なエラー"));
     } finally {
       setIsProcessing(false);
     }

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -100,7 +100,7 @@ export default function HtmlToImageTool() {
   // スケールファクター
   const scaleFactor = 360/baseWidth;
   
-  // HTML要素から画像を生成して保存 - 直接DOM APIを使用
+  // HTML要素から画像を生成して保存 - 直接Canvas APIを使用
   const saveAsImage = async () => {
     if (!textContainerRef.current || isProcessing) return;
     
@@ -245,7 +245,7 @@ export default function HtmlToImageTool() {
               whiteSpace: 'pre-line', // 明示的な改行のみを反映
               zIndex: 1
             }}
-            dangerouslySetInnerHTML={{ __html: upperHtml }}
+            dangerouslySetInnerHTML={{ __html: bottomHtml }}
           />
         </div>
         

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -14,7 +14,7 @@ export default function HtmlToImageTool() {
   const [fontWeight, setFontWeight] = useState(400);
   const [lineHeight, setLineHeight] = useState(1.4); // 行間の比率を追加
   const [upperTextTop, setUpperTextTop] = useState(60); // 上部テキストの位置
-  const [bottomTextBottom, setBottomTextBottom] = useState(220); // 下部テキストの位置
+  const [bottomTextBottom, setBottomTextBottom] = useState(180); // 下部テキストの位置
   const [isProcessing, setIsProcessing] = useState(false);
   const previewRef = useRef(null);
   const textContainerRef = useRef(null); // テキスト要素のみを含むコンテナへの参照

--- a/src/app/components/HtmlToImageTool/page.js
+++ b/src/app/components/HtmlToImageTool/page.js
@@ -1,13 +1,14 @@
 'use client';
 
 import { useState, useRef, useEffect } from "react";
+import { toBlob } from 'html-to-image';
 
 export default function HtmlToImageTool() {
   const [markupUpperText, setMarkupUpperText] = useState(``);
   const [markupBottomText, setMarkupBottomText] = useState(``);
 
   // 状態変数に設定パネル表示フラグを追加
-const [showSettings, setShowSettings] = useState(false);
+  const [showSettings, setShowSettings] = useState(false);
   const [textRate, setTextRate] = useState(3.3);
   const [selectedFont, setSelectedFont] = useState("lanobe-pop");
   const [fontWeight, setFontWeight] = useState(400);
@@ -16,6 +17,7 @@ const [showSettings, setShowSettings] = useState(false);
   const [bottomTextBottom, setBottomTextBottom] = useState(220); // 下部テキストの位置
   const [isProcessing, setIsProcessing] = useState(false);
   const previewRef = useRef(null);
+  const textContainerRef = useRef(null); // テキスト要素のみを含むコンテナへの参照
   
   // 利用可能なフォントリスト
   const availableFonts = [
@@ -92,72 +94,37 @@ const [showSettings, setShowSettings] = useState(false);
   const baseWidth = 1080;
   const baseHeight = 1920;
   
-  // 赤領域の絶対座標と大きさ
+  // 緑領域の絶対座標と大きさ
   const redAreaTop = 500;
   const redAreaHeight = 680;
   
   // スケールファクター
   const scaleFactor = 360/baseWidth;
   
-  // APIを呼び出して画像を生成・保存
-  // APIを呼び出して画像を生成・保存
-const saveAsImage = async () => {
-  if (!previewRef.current || isProcessing) return;
-  
-  setIsProcessing(true);
-  
-  try {
-    // タイムスタンプ生成
-    const now = new Date();
-    const timestamp = `${now.getFullYear()}${(now.getMonth()+1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
+  // HTML要素から画像を生成して保存
+  const saveAsImage = async () => {
+    if (!textContainerRef.current || isProcessing) return;
     
-    // スタイル情報を含めたデータを準備
-    const requestData = {
-      upperText: markupUpperText,
-      bottomText: markupBottomText,
-      timestamp: timestamp,
-      colorMap: colorMap,
-      selectedFont: selectedFont,
-      fontWeight: fontWeight,
-      styles: {
-        // 基本レイアウト情報
-        width: 360,
-        height: 640,
-        // 出力サイズ (9:16のアスペクト比)
-        outputWidth: 1080,
-        outputHeight: 1920,
-        // テキスト位置
-        upperTextTop: upperTextTop,
-        bottomTextBottom: bottomTextBottom,
-        // テキストスタイル
-        fontSize: 24 * scaleFactor * textRate,
-        fontFamily: selectedFont,
-        fontWeight: fontWeight,
-        lineHeight: lineHeight,
-        // 赤エリア情報（必要に応じて）
-        redAreaTop: redAreaTop * scaleFactor,
-        redAreaHeight: redAreaHeight * scaleFactor
-      }
-    };
+    setIsProcessing(true);
+    
+    try {
+      // タイムスタンプ生成
+      const now = new Date();
+      const timestamp = `${now.getFullYear()}${(now.getMonth()+1).toString().padStart(2, '0')}${now.getDate().toString().padStart(2, '0')}_${now.getHours().toString().padStart(2, '0')}${now.getMinutes().toString().padStart(2, '0')}${now.getSeconds().toString().padStart(2, '0')}`;
       
-      // APIエンドポイントを呼び出し
-      const response = await fetch('/api/generate-image', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(requestData),
+      // テキスト要素のみを含むコンテナからBlobを生成
+      const blob = await toBlob(textContainerRef.current, {
+        backgroundColor: null, // 透明な背景
+        width: 1080,
+        height: 1920
       });
       
-      if (!response.ok) {
-        throw new Error(`APIエラー: ${response.status}`);
+      if (!blob) {
+        throw new Error("画像の生成に失敗しました");
       }
       
-      // レスポンスが画像データ(Blob)
-      const imageBlob = await response.blob();
-      
       // Blobオブジェクトから一時的なURLを作成
-      const imageUrl = URL.createObjectURL(imageBlob);
+      const imageUrl = URL.createObjectURL(blob);
       
       // ダウンロードリンク作成
       const link = document.createElement('a');
@@ -178,11 +145,6 @@ const saveAsImage = async () => {
     }
   };
   
-
-
-
-
-
   // モバイルエリアコンポーネント
   const MobilArea = ({ textRate = 1 }) => {
     return (
@@ -194,39 +156,68 @@ const saveAsImage = async () => {
         ref={previewRef}
         id="preview-container"
       >
-        {/* 上部テキスト - 絶対配置 */}
-        <div
-          className="text-center upper-text"
-          style={{
-            position: "absolute",
-            top: `${upperTextTop}px`,
-            left: "0",
-            width: "100%",
-            padding: '0',
-            fontSize: `${24 * scaleFactor * textRate}px`,
-            lineHeight: lineHeight,
-            fontFamily: selectedFont,
-            fontWeight: fontWeight,
-            whiteSpace: 'pre-wrap',
-            zIndex: 1
-          }}
-          dangerouslySetInnerHTML={{ __html: upperHtml }}
-        />
-        
-        {/* 中央の赤帯を目に優しい薄い緑色に変更 */}
+        {/* テキスト要素のみを含むコンテナ（透明背景） */}
         <div 
-          className="red-area"
+          ref={textContainerRef}
+          className="absolute top-0 left-0 w-full h-full"
+          style={{
+            backgroundColor: "transparent",
+            overflow: "hidden"
+          }}
+        >
+          {/* 上部テキスト - 絶対配置 */}
+          <div
+            className="text-center upper-text"
+            style={{
+              position: "absolute",
+              top: `${upperTextTop}px`,
+              left: "0",
+              width: "100%",
+              padding: '0',
+              fontSize: `${24 * scaleFactor * textRate}px`,
+              lineHeight: lineHeight,
+              fontFamily: selectedFont,
+              fontWeight: fontWeight,
+              whiteSpace: 'pre-line', // 明示的な改行のみを反映
+              zIndex: 1
+            }}
+            dangerouslySetInnerHTML={{ __html: upperHtml }}
+          />
+          
+          {/* 下部テキスト - 絶対配置 */}
+          <div
+            className="text-center bottom-text"
+            style={{
+              position: "absolute",
+              bottom: `${bottomTextBottom}px`,
+              left: "0",
+              width: "100%",
+              padding: '0',
+              fontSize: `${24 * scaleFactor * textRate}px`,
+              lineHeight: lineHeight,
+              fontFamily: selectedFont,
+              fontWeight: fontWeight,
+              whiteSpace: 'pre-line', // 明示的な改行のみを反映
+              zIndex: 1
+            }}
+            dangerouslySetInnerHTML={{ __html: bottomHtml }}
+          />
+        </div>
+        
+        {/* 中央の緑帯 - プレビュー用（テキストコンテナの外に配置） */}
+        <div 
+          className="green-area"
           style={{
             position: 'absolute',
             top: `${redAreaTop * scaleFactor}px`,
             left: "0",
             width: "100%",
             height: `${redAreaHeight * scaleFactor}px`,
-            backgroundColor: '#90EE90', // 'red'から'#90EE90'（light green）に変更
+            backgroundColor: '#90EE90', // 薄い緑色
             zIndex: 0
           }} 
         >
-          {/* 領域の中央に仮のテキスト */}
+          {/* 緑領域の中央に仮のテキスト */}
           <div
             style={{
               position: 'absolute',
@@ -241,33 +232,14 @@ const saveAsImage = async () => {
             ここに画像が入ります
           </div>
         </div>
-        
-        {/* 下部テキスト - 絶対配置 */}
-        <div
-          className="text-center bottom-text"
-          style={{
-            position: "absolute",
-            bottom: `${bottomTextBottom}px`,
-            left: "0",
-            width: "100%",
-            padding: '0',
-            fontSize: `${24 * scaleFactor * textRate}px`,
-            lineHeight: lineHeight,
-            fontFamily: selectedFont,
-            fontWeight: fontWeight,
-            whiteSpace: 'pre-wrap',
-            zIndex: 1
-          }}
-          dangerouslySetInnerHTML={{ __html: bottomHtml }}
-        />
       </div>
     );
   };
 
   // 設定パネル表示切り替え関数
-const toggleSettings = () => {
-  setShowSettings(!showSettings);
-};
+  const toggleSettings = () => {
+    setShowSettings(!showSettings);
+  };
   
   return (
     <div className="flex flex-row gap-4 p-4">


### PR DESCRIPTION
## 改善内容

このプルリクエストは、TextRenderツールのテキスト画像出力機能を大幅に改善し、以下の問題を解決します：

1. **色情報の保持**: カラータグで指定したテキスト色が画像出力に正確に反映されます
2. **フォント情報の保持**: 選択したフォント、太さ、サイズが画像出力に忠実に再現されます
3. **改行問題の解決**: テキストの改行が意図したとおりに表示されます

## 主な変更点

1. バックエンドAPIに依存した実装から、クライアントサイドのみで完結する実装に変更
2. html2canvasライブラリを使用して「見たままを出力する」アプローチを採用
3. 中央の領域の背景色を目に優しい薄い緑色に変更

## 技術的なアプローチ

第一原理思考に基づき、「見たものをそのまま出力する」という本質的な目的に最短で到達するアプローチを選択しました。これにより：

- ユーザーが期待するとおりの出力結果が得られる
- サーバーへの通信が不要になり、処理が高速化
- 複雑な実装ロジックが大幅に簡略化

## テスト方法

1. 複数の色を含むテキストを入力
2. 様々なフォントと太さを選択
3. 改行を含むテキストを試す
4. 画像を保存して結果を確認

## スクリーンショット

（参考：上部に「志摩リンは当初、自転車でキャンプに行っていた」、下部に「遠出もするように 原付スクーターのモデルはヤマハ・ビーノ」など色付きテキストを表示した例）